### PR TITLE
Fix app path bug

### DIFF
--- a/bin/mpcmf
+++ b/bin/mpcmf
@@ -42,12 +42,11 @@ if(!file_exists($appPath) || !is_readable($appPath)) {
     exit(1);
 }
 
-$appName = basename($argv[1], '.php');
+$appFullClassPath = APP_NAME . DIRECTORY_SEPARATOR . dirname($argv[1]) . DIRECTORY_SEPARATOR . basename($argv[1], '.php');
 
 unset($argv[1]);
 $argv = array_values($argv);
 $_SERVER['argv'] = $argv;
-$appFullClassPath = dirname(str_replace(APP_ROOT, APP_NAME, $appPath)) . DIRECTORY_SEPARATOR . $appName;
 
 $appFullClass = str_replace(DIRECTORY_SEPARATOR, config::NAMESPACE_SEPARATOR, preg_replace('/\/vendor\/[^\/]+\/[^\/]+\/src/ui', '', $appFullClassPath));
 


### PR DESCRIPTION
If mpcmf-webApp is deployed in a directory whose name is part of the application path, `mpcmf.php` incorrectly determines the application class at runtime.

For example, the path `default/apps/defaultApp/console` is transformed into the class `mpcmf\appsmpcmfApp\console`. To fix this, either replace only the first occurrence of the root directory name or, as proposed in the PR, construct the class name without performing replacements in the full path.